### PR TITLE
Include the receiver object in the widget context

### DIFF
--- a/phileo/utils.py
+++ b/phileo/utils.py
@@ -53,6 +53,7 @@ def widget_context(user, obj):
         "can_like": can_like,
         "like_count": like_count,
         "counts_text": counts_text,
+        "object": obj,
     }
 
     if can_like:


### PR DESCRIPTION
Adds the `receiver_object` to the context passed to the widget.

Allows the developer to further customize how the widget is used on a site.